### PR TITLE
v1.12.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GlycoDash
 Title: GlycoDash
-Version: 1.12.0
+Version: 1.12.1
 Authors@R: c(
     person("Steinar", "Gijze", email = "s.gijze@lumc.nl", role = c("aut", "cre")),
     person("Sterre", "Siekman", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# v1.12.1
+## Changed
+- Remove `mz_exact` as a required column in SweetSuite data. The values are 
+not required for processing, and the column is renamed in newer SweetSuite
+versions.
+
+
 # v1.12.0
 ## Added
 * Data import: option to merge Skyline data with GlyCounter fragmentation data.

--- a/R/fct_read_sweetsuite.R
+++ b/R/fct_read_sweetsuite.R
@@ -37,7 +37,7 @@ read_sweetsuite_data <- function(datapaths) {
     
     # Check for required columns
     required_cols <- c(
-      "file", "analyte", "charge", "mz_exact", "isotopic_fraction",
+      "file", "analyte", "charge", "isotopic_fraction",
       "total_area_background_subtracted", "mass_error_ppm",
       "isotopic_pattern_quality", "signal_to_noise"
     )


### PR DESCRIPTION
Remove `mz_exact` as a required column in SweetSuite data, because the values are not required and this column is renamed in newer SweetSuite versions.